### PR TITLE
Metadata carousel

### DIFF
--- a/src/pages/cms.js
+++ b/src/pages/cms.js
@@ -16,6 +16,7 @@ const CMS = () => {
   const [productId, setProductId] = useState('');
   const [name, setName] = useState('');
   const [active, setActive] = useState(false);
+  const [onCarousel, setOnCarousel] = useState(false);
   const [desc, setDesc] = useState('');
   // for the separated images url thingy, i was thinking we
   // could just take the whole string and break it into
@@ -96,6 +97,7 @@ const CMS = () => {
       ? setFeaturedImg(prod.metadata.featuredImg)
       : null;
     prod.metadata.modelInfo ? setFeaturedImg(prod.metadata.modelInfo) : null;
+    prod.metadata.onCarousel ? setOnCarousel(prod.metadata.onCarousel) : false;
   };
 
   const handleUpdateProduct = async () => {
@@ -111,6 +113,7 @@ const CMS = () => {
     newProduct.metadata = {
       featuredImg,
       modelInfo,
+      onCarousel,
     };
     const prod = await updateProduct(productId, newProduct);
     prod.statusCode
@@ -240,19 +243,24 @@ const CMS = () => {
           </div>
         </div>
 
+
         <div className="cms__field">
           <p className="cms__label">Active</p>
           <div>
-            <input
-              placeholder="true/false"
-              type="checkbox"
-              checked={active}
-              onChange={() => {
-                setActive(!active);
-              }}
-              disabled={!edit}
-              className="cms__checkbox"
-            />
+            <select onChange={(e)=>setActive(e.target.value)} value={active}>
+              <option value="true">true</option>
+              <option value="false">false</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="cms__field">
+          <p className="cms__label">Show On Carousel</p>
+          <div>
+            <select onChange={(e)=>setOnCarousel(e.target.value)} value={onCarousel}>
+              <option value="true">true</option>
+              <option value="false">false</option>
+            </select>
           </div>
         </div>
 

--- a/src/pages/cms.js
+++ b/src/pages/cms.js
@@ -97,7 +97,7 @@ const CMS = () => {
       ? setFeaturedImg(prod.metadata.featuredImg)
       : null;
     prod.metadata.modelInfo ? setFeaturedImg(prod.metadata.modelInfo) : null;
-    prod.metadata.onCarousel ? setOnCarousel(prod.metadata.onCarousel) : false;
+    prod.metadata.onCarousel ? setOnCarousel(prod.metadata.onCarousel) : setOnCarousel(false);
   };
 
   const handleUpdateProduct = async () => {
@@ -247,7 +247,7 @@ const CMS = () => {
         <div className="cms__field">
           <p className="cms__label">Active</p>
           <div>
-            <select onChange={(e)=>setActive(e.target.value)} value={active}>
+            <select onChange={(e)=>setActive(e.target.value)} value={active} disabled={!edit}>
               <option value={true}>true</option>
               <option value={false}>false</option>
             </select>
@@ -257,7 +257,7 @@ const CMS = () => {
         <div className="cms__field">
           <p className="cms__label">Show On Carousel</p>
           <div>
-            <select onChange={(e)=>setOnCarousel(e.target.value)} value={onCarousel}>
+            <select onChange={(e)=>setOnCarousel(e.target.value)} value={onCarousel} disabled={!edit}>
               <option value={true}>true</option>
               <option value={false}>false</option>
             </select>

--- a/src/pages/cms.js
+++ b/src/pages/cms.js
@@ -248,8 +248,8 @@ const CMS = () => {
           <p className="cms__label">Active</p>
           <div>
             <select onChange={(e)=>setActive(e.target.value)} value={active}>
-              <option value="true">true</option>
-              <option value="false">false</option>
+              <option value={true}>true</option>
+              <option value={false}>false</option>
             </select>
           </div>
         </div>
@@ -258,8 +258,8 @@ const CMS = () => {
           <p className="cms__label">Show On Carousel</p>
           <div>
             <select onChange={(e)=>setOnCarousel(e.target.value)} value={onCarousel}>
-              <option value="true">true</option>
-              <option value="false">false</option>
+              <option value={true}>true</option>
+              <option value={false}>false</option>
             </select>
           </div>
         </div>

--- a/src/pages/shop.js
+++ b/src/pages/shop.js
@@ -161,7 +161,7 @@ export default Shop;
 
 export const query = graphql`
   query MyQuery {
-    allStripeProduct(filter: { active: { eq: true } }) {
+    allStripeProduct(filter: { active: { eq: true }, metadata: {onCarousel: {eq: "true"} }}) {
       edges {
         node {
           id


### PR DESCRIPTION
- carousel now shows only products with metadata.onCarousel="true"
- since it's under metadata, it does some weird casting to string instead of boolean, it works for now
- metadata.onCarousel and active are both available in cms now